### PR TITLE
Render PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ overview](https://github.com/fieldpapers/fieldpapers).
 
 ### Using fig
 
+_NOTE_: this method is not actively being used, so there will be missing
+pieces.
+
 [`fig`](http://www.fig.sh/) is a [Docker](http://www.docker.com/)-based tool for
 orchestrating development environments. Rather than using `foreman` to manage
 multiple processes locally, `fig` runs each component process in a separate
@@ -79,8 +82,15 @@ A default `.envrc` has been provided that adds `bin/` to your `PATH`
 (`$(pwd)/bin`, technically, to prevent abuse) so that bundler binstubs can be
 used. It's opt-in, so you'll need to enable it with `direnv allow .`.
 
+Ghostscript is used to merge atlas pages together into a single PDF, so you'll
+need that (and `boot2docker` generate individual pages) to generate atlases.
+
 ```bash
-brew install rbenv ruby-build direnv
+brew install rbenv ruby-build direnv ghostscript boot2docker
+
+boot2docker init         # create the Docker host if necessary
+boot2docker up           # start the Docker host
+$(boot2docker shellinit) # set the necessary Docker environment vars
 
 eval "$(rbenv init -)"     # initialize rbenv
 eval "$(direnv hook bash)" # initialize direnv

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -1,7 +1,94 @@
+require "timeout"
+
 class GeneratePdfJob < ActiveJob::Base
   queue_as :default
 
-  def perform(slug)
-    puts "Generating PDF for #{slug}"
+  def perform(atlas)
+    base_cmd = %w(docker run fieldpapers/paper)
+
+    files = atlas.pages.map do |page|
+      cmd = base_cmd.dup
+
+      case page.page_number
+      when "i"
+        cmd << "create_index.py"
+        cmd << "-s" << page.atlas.paper_size
+        cmd << "-l" << page.atlas.layout
+        cmd << "-o" << page.atlas.orientation
+        cmd << "-b" << page.north << page.west << page.south << page.east
+        cmd << "-e" << page.atlas.north << page.atlas.west << page.atlas.south << page.atlas.east
+        cmd << "-z" << page.zoom
+        cmd << "-p" << page.provider
+        cmd << "-c" << page.atlas.cols
+        cmd << "-r" << page.atlas.rows
+        cmd << page.atlas.slug
+      else
+        cmd << "create_page.py"
+        cmd << "-s" << page.atlas.paper_size
+        cmd << "-l" << page.atlas.layout
+        cmd << "-o" << page.atlas.orientation
+        cmd << "-b" << page.north << page.west << page.south << page.east
+        cmd << "-n" << page.page_number
+        cmd << "-z" << page.zoom
+        cmd << "-p" << page.provider
+        cmd << page.atlas.slug
+      end
+
+      # convert all arguments to strings
+      cmd = cmd.map(&:to_s)
+
+      pipe, status = nil
+
+      begin
+        Timeout.timeout(30) do
+          pipe = IO.popen(cmd)
+
+          (pid, status) = Process.wait2(pipe.pid)
+        end
+      rescue Timeout::Error
+        Process.kill 9, pipe.pid
+        Process.wait pipe.pid
+
+        raise "Timed out waiting to render page #{page.page_number} of #{atlas.slug}"
+      end
+
+      unless status.success?
+        raise "Failed to render page #{page.page_number} of #{atlas.slug}"
+      end
+
+      output = Tempfile.new(["page", ".pdf"], "tmp/")
+
+      IO.copy_stream(pipe, output)
+
+      output.path
+    end
+
+    if atlas.pages.size > 1
+      gs = %w(gs -q -sDEVICE=pdfwrite -o -)
+
+      gs.concat(files)
+
+      pdf = IO.popen(gs)
+
+      (pid, status) = Process.wait2(pdf.pid)
+
+      unless status.success?
+        raise "Failed to merge pages for #{atlas.slug}"
+      end
+
+      atlas = Tempfile.new(["atlas", ".pdf"], "tmp/")
+
+      IO.copy_stream(pdf, atlas)
+
+      # upload file to S3
+      # attach file to Atlas
+
+      puts "atlas: #{atlas.path}"
+    else
+      # upload file to S3
+      # attach file to Atlas
+
+      puts "atlas: #{files.first}"
+    end
   end
 end

--- a/app/models/atlas.rb
+++ b/app/models/atlas.rb
@@ -179,16 +179,18 @@ private
   def create_pages
     # create index page
 
-    pages.create! \
-      page_number: "i",
-      west: west - west * INDEX_BUFFER_FACTOR,
-      south: south - south * INDEX_BUFFER_FACTOR,
-      east: east + east * INDEX_BUFFER_FACTOR,
-      north: north + north * INDEX_BUFFER_FACTOR,
-      zoom: zoom, # TODO should be calculated from the bounding box; see
-                  #   https://gist.github.com/mojodna/9a4e28ec70e685066c03
-      # omit UTM overlays (if present) from the index page
-      provider: provider.gsub("http://tile.stamen.com/utm/{Z}/{X}/{Y}.png", "")
+    if rows * cols > 1
+      pages.create! \
+        page_number: "i",
+        west: west - west * INDEX_BUFFER_FACTOR,
+        south: south - south * INDEX_BUFFER_FACTOR,
+        east: east + east * INDEX_BUFFER_FACTOR,
+        north: north + north * INDEX_BUFFER_FACTOR,
+        zoom: zoom, # TODO should be calculated from the bounding box; see
+                    #   https://gist.github.com/mojodna/9a4e28ec70e685066c03
+        # omit UTM overlays (if present) from the index page
+        provider: provider.gsub("http://tile.stamen.com/utm/{Z}/{X}/{Y}.png", "")
+    end
 
     # create individual pages
 
@@ -226,6 +228,6 @@ private
   end
 
   def generate_pdf
-    GeneratePdfJob.perform_later(self.slug)
+    GeneratePdfJob.perform_later(self)
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.active_job.queue_adapter = :test
 end


### PR DESCRIPTION
Render PDF atlases (and upload them to S3) using a Docker container ([fieldpapers/paper](https://github.com/stamen/fieldpapers/blob/modernize/decoder/Dockerfile)) + Ghostscript.

It still picks incorrect zooms, resulting in black images.