### PR TITLE
Add maps.sputnik.ru tile provider

### DIFF
--- a/lib/providers.rb
+++ b/lib/providers.rb
@@ -30,6 +30,8 @@ class Providers
       'mapbox-satellite'
     elsif url.include? 'opencyclemap.org'
       'opencyclemap'
+    elsif url.include? 'sputnik.ru'
+      'sputnik.ru'
     else
       url
     end
@@ -126,6 +128,15 @@ class Providers
         },
         minzoom: 0,
         maxzoom: 20,
+      },
+      'sputnik.ru': {
+        label: 'Sputnik.RU',
+        template: 'http://{S}.tiles.maps.sputnik.ru/{z}/{x}/{y}.png',
+        options: {
+          attribution: ' © <a href="http://sputnik.ru">Спутник</a> | © <a href="http://www.openstreetmap.org/copyright">Openstreetmap</a> | © <a href="http://www.naturalearthdata.com/about/terms-of-use/">Natural Earth</a> '
+        },
+        minzoom: 0,
+        maxzoom: 19,
       },
 
     }


### PR DESCRIPTION
Hi! I want to add our osm-based tile layer (from http://maps.sputnik.ru/).
Parameters are:

parameter     | value
---------------- | --------
url template | http://{s}.tiles.maps.sputnik.ru/{z}/{x}/{y}.png
min zoom    | 0
max zoom   | 19
attribution    | ```© <a href="http://sputnik.ru">Спутник</a> | © <a href="http://www.openstreetmap.org/copyright">Openstreetmap</a> | © <a href="http://www.naturalearthdata.com/about/terms-of-use/">Natural Earth</a>```

I has tried to create a patch. But it's difficult to test it for me. What about sputnik.ru layer on fieldpapers? :smiley_cat: 