### PR TITLE
API endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "gettext_i18n_rails" # gettext-style i18n
 gem "has_scope" # automatic filter generation
 gem "http_accept_language"
 gem "kaminari" # pagination
+gem 'api-pagination'
 gem "leaflet-rails", git: 'https://github.com/stamen/leaflet-rails'
 gem "paperclip", "~> 4.2.1" # file attachments
 gem "puma" # app server
@@ -84,6 +85,7 @@ group :development, :test do
 
   gem "meta_request" # to support https://github.com/dejan/rails_panel
   gem "minitest-reporters"
+  gem "fakeweb"
 
   gem "rake"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       activerecord (>= 3.2, <= 4.3)
       rake (~> 10.4)
     ansi (1.5.0)
+    api-pagination (4.1.1)
     arel (6.0.3)
     autoprefixer-rails (6.0.3)
       execjs
@@ -122,6 +123,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.8)
     execjs (2.6.0)
+    fakeweb (1.3.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
@@ -328,6 +330,7 @@ PLATFORMS
 DEPENDENCIES
   actionview-encoded_mail_to
   annotate (~> 2.6.5)
+  api-pagination
   aws-sdk-core (~> 2)
   aws-sdk-v1 (~> 1)
   aws-ses!
@@ -337,6 +340,7 @@ DEPENDENCIES
   devise
   devise-i18n
   devise-i18n-views
+  fakeweb
   faraday
   faraday_middleware
   friendly_id (~> 5.1.0)

--- a/app/controllers/api/v1/atlases_controller.rb
+++ b/app/controllers/api/v1/atlases_controller.rb
@@ -1,0 +1,98 @@
+require 'api-pagination'
+
+module Api
+  module V1
+    class AtlasesController < ApplicationController
+      include AtlasesHelper
+      include SnapshotsHelper
+
+      respond_to :json
+      before_filter :find_atlas, only: [:show, :update, :destroy, :status, :page]
+
+      skip_before_filter :verify_authenticity_token
+
+      has_scope :date,  only: :index
+      has_scope :month, only: :index
+      has_scope :place, only: :index
+      has_scope :user,  only: :index
+
+      def index
+        paginate json: apply_scopes(Atlas.unscoped).default { |a| atlas_to_geojson(a) }
+      end
+
+      def show
+        respond_to do |format|
+          format.json { render_atlas }
+          format.pdf  { redirect_to @atlas.pdf_url, status: :see_other }
+        end
+      end
+
+      def create
+        @atlas = Atlas.create atlas_params
+        if @atlas.valid?
+          @atlas.save
+          @atlas.render!
+          render_atlas
+        else
+          render status: :bad_request,
+                 json: { message: "Failed to create new atlas" }
+        end
+      end
+
+      def update
+        @atlas.update(atlas_params)
+        render_atlas
+      end
+
+      def destroy
+        @atlas.destroy
+        render_atlas
+      end
+
+      def status
+        render json: { progress: @atlas.progress,
+                       workflow_state: @atlas.workflow_state,
+                       composed_at: @atlas.composed_at,
+                       created_at: @atlas.created_at,
+                       failed_at: @atlas.failed_at,
+                       updated_at: @atlas.updated_at }
+      end
+
+      def page
+        begin
+          page = @atlas.pages.find_by_page_number(params[:page_number])
+          respond_to do |format|
+            format.json { render json: page_to_geojson(@atlas, page) }
+            format.pdf  { redirect_to page.pdf_url, status: :see_other }
+          end
+        rescue ActiveRecord::RecordNotFound
+          render status: :not_found,
+                 json: { message: "Page '#{params[:page_number]} not " \
+                                  "found in atlas '#{params[:id]}'" }
+        end
+      end
+
+      private
+
+      def find_atlas
+        begin
+          @atlas = Atlas.unscoped.friendly.find(params[:id])
+        rescue ActiveRecord::RecordNotFound
+          render status: :not_found,
+                 json: { message: "Atlas ID '#{params[:id]}' not found" }
+        end
+      end
+
+      def render_atlas
+        render json: atlas_to_geojson(@atlas)
+      end
+
+      def atlas_params
+        params.require(:atlas).permit \
+          :north, :south, :east, :west, :zoom, :rows, :cols,
+          :paper_size, :orientation, :layout, :provider,
+          :title, :text, :private, :utm_grid, :redcross_overlay
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/s3_upload_controller.rb
+++ b/app/controllers/api/v1/s3_upload_controller.rb
@@ -1,0 +1,33 @@
+# To upload images for new snapshots via the API, we use pre-signed S3
+# URLs -- this is a simpler approach for API users since it removes
+# the need to deal with any AWS authorisation issues: the client just
+# does a PUT to the provided upload URL with the right Content-Type
+# and things just work.  The client then passes the public URL of the
+# uploaded S3 object in the API call to create a new snapshot.  (This
+# feels like a bit of a bodge, but it's pretty much equivalent to the
+# approach used for browser-based uploads.)
+
+module Api
+  module V1
+    class S3UploadController < ApplicationController
+      respond_to :json
+      skip_before_filter :verify_authenticity_token
+
+      def show
+        bucket = Rails.application.secrets.aws["s3_bucket_name"]
+        region = Rails.application.secrets.aws["s3_bucket_region"]
+        filename = params[:filename] + (params[:format] ? ('.' + params[:format]) : '')
+
+        s3 = AWS::S3.new(region: region)
+        key = "uploads/" + SecureRandom.urlsafe_base64 + "/" + filename
+        obj = s3.buckets[bucket].objects[key]
+        content_type = "image/" + filename.split('.')[-1]
+        upload_url = obj.url_for(:write, :content_type => content_type).to_s
+
+        render json: { bucket: bucket, region: region, key: key,
+                       public_url: obj.public_url.to_s,
+                       upload_url: upload_url, upload_content_type: content_type }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/snapshots_controller.rb
+++ b/app/controllers/api/v1/snapshots_controller.rb
@@ -1,0 +1,82 @@
+require 'api-pagination'
+
+module Api
+  module V1
+    class SnapshotsController < ApplicationController
+      include AtlasesHelper
+      include SnapshotsHelper
+
+      respond_to :json
+      before_filter :find_snapshot, only: [:show, :destroy, :status, :page]
+
+      skip_before_filter :verify_authenticity_token
+
+      has_scope :date, only: :index
+      has_scope :month, only: :index
+      has_scope :place, only: :index
+      has_scope :user, only: :index
+
+      def index
+        paginate({ json: apply_scopes(Snapshot.unscoped).default do |s|
+                     snapshot_to_geojson(s.atlas_id ?
+                                           Atlas.find(s.atlas_id) : nil, s)
+                   end })
+      end
+
+      def show
+        respond_to do |format|
+          format.png  { redirect_to @snapshot.s3_scene_url, status: :see_other }
+          format.json { render_snapshot }
+          format.tiff { redirect_to @snapshot.geotiff_url, status: :see_other }
+        end
+      end
+
+      def create
+        begin
+          @snapshot = Snapshot.create!(snapshot_upload_params)
+          @snapshot.process!
+          render_snapshot
+        rescue
+          render status: :bad_request,
+                 json: { message: "Failed to create new snapshot" }
+        end
+      end
+
+      def destroy
+        @snapshot.destroy
+        render_snapshot
+      end
+
+      def status
+        render json: { progress: @snapshot.progress,
+                       has_geotiff: @snapshot.has_geotiff,
+                       has_geojpeg: @snapshot.has_geojpeg,
+                       decoded_at: @snapshot.decoded_at,
+                       created_at: @snapshot.created_at,
+                       failed_at: @snapshot.failed_at,
+                       updated_at: @snapshot.updated_at }
+      end
+
+      private
+
+      def find_snapshot
+        begin
+          @snapshot = Snapshot.unscoped.friendly.find(params[:id])
+        rescue ActiveRecord::RecordNotFound
+          render status: :not_found,
+                 json: { message: "Snapshot ID '#{params[:id]}' not found" }
+        end
+      end
+
+      def render_snapshot
+        atlas = @snapshot.atlas_id ? Atlas.find(@snapshot.atlas_id) : nil
+        render json: snapshot_to_geojson(atlas, @snapshot)
+      end
+
+
+      def snapshot_upload_params
+        params.permit(:s3_scene_url)
+      end
+    end
+  end
+end

--- a/app/helpers/api/v1/atlas_helper.rb
+++ b/app/helpers/api/v1/atlas_helper.rb
@@ -1,0 +1,2 @@
+module Api::V1::AtlasHelper
+end

--- a/app/helpers/atlases_helper.rb
+++ b/app/helpers/atlases_helper.rb
@@ -52,73 +52,92 @@ module AtlasesHelper
     feature[:geometry][:coordinates] = polys
     out[:features].push(feature)
 
-    # create pages
     atlas.pages.each do |page|
-      bbox = page.bbox
-
-      out[:features].push({
-        type: 'Feature',
-        properties: {
-          type: 'page',
-          provider: page.provider,
-          page_number: page.page_number,
-          zoom: page.zoom,
-          created: page.created_at.strftime('%a, %e %b %Y %H:%M:%S %z'),
-          url: atlas_url(atlas) + "/" + page.page_number,
-        },
-        geometry: {
-          type: 'Polygon',
-          coordinates: [[
-            [bbox[0],bbox[1]],
-            [bbox[0],bbox[3]],
-            [bbox[2],bbox[3]],
-            [bbox[2],bbox[1]],
-            [bbox[0],bbox[1]]
-          ]]
-        }
-      })
+      create_page_feature(atlas, page, out)
     end
-
-
-    # create snapshot features
     atlas.snapshots.each do |snapshot|
-      bbox = snapshot.bbox
-
-      out[:features].push({
-        type: 'Feature',
-        properties: {
-          type: 'snapshot',
-          title: snapshot.title,
-          description: snapshot.description,
-          uploader: snapshot.uploader_name,
-          created: snapshot.created_at.strftime('%a, %e %b %Y %H:%M:%S %z'),
-          min_row: snapshot.min_row,
-          max_row: snapshot.max_row,
-          min_column: snapshot.min_column,
-          max_column: snapshot.max_column,
-          min_zoom: snapshot.min_zoom,
-          max_zoom: snapshot.max_zoom,
-          base_url: snapshot.base_url,
-          url: snapshot_url(snapshot),
-          url_page: atlas_url(atlas) + "/" + snapshot.page.page_number,
-          url_uploader: snapshot_person_href(snapshot),
-        },
-        geometry: {
-          type: 'Polygon',
-          coordinates: [[
-            [bbox[0],bbox[1]],
-            [bbox[0],bbox[3]],
-            [bbox[2],bbox[3]],
-            [bbox[2],bbox[1]],
-            [bbox[0],bbox[1]]
-          ]]
-        }
-      })
+      create_snapshot_feature(atlas, snapshot, out)
     end
-
     # notes features?
 
     return out
   end # end atlas_to_geojson
 
+
+  def page_to_geojson(atlas, page)
+    out = { type: 'FeatureCollection', features: [] }
+    create_page_feature(atlas, page, out)
+    return out
+  end # end page_to_geojson
+
+  def create_page_feature(atlas, page, out)
+    # create pages
+    bbox = page.bbox
+
+    out[:features].push({
+      type: 'Feature',
+      properties: {
+        type: 'page',
+        provider: page.provider,
+        page_number: page.page_number,
+        zoom: page.zoom,
+        created: page.created_at.strftime('%a, %e %b %Y %H:%M:%S %z'),
+        url: atlas_url(atlas) + "/" + page.page_number,
+      },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[
+          [bbox[0],bbox[1]],
+          [bbox[0],bbox[3]],
+          [bbox[2],bbox[3]],
+          [bbox[2],bbox[1]],
+          [bbox[0],bbox[1]]
+        ]]
+      }
+    })
+  end
+
+
+  def snapshot_to_geojson(atlas, snapshot)
+    out = { type: 'FeatureCollection', features: [] }
+    create_snapshot_feature(atlas, snapshot, out)
+    return out
+  end # end snapshot_to_geojson
+
+  def create_snapshot_feature(atlas, snapshot, out)
+    # create snapshot features
+    bbox = snapshot.bbox
+
+    out[:features].push({
+      type: 'Feature',
+      properties: {
+        type: 'snapshot',
+        title: snapshot.atlas_id ? snapshot.title : '',
+        description: snapshot.description,
+        uploader: snapshot.uploader_name,
+        created: snapshot.created_at.strftime('%a, %e %b %Y %H:%M:%S %z'),
+        min_row: snapshot.min_row,
+        max_row: snapshot.max_row,
+        min_column: snapshot.min_column,
+        max_column: snapshot.max_column,
+        min_zoom: snapshot.min_zoom,
+        max_zoom: snapshot.max_zoom,
+        base_url: snapshot.base_url,
+        url: snapshot_url(snapshot),
+        url_page: atlas && snapshot.page ?
+          atlas_url(atlas) + "/" + snapshot.page.page_number : '',
+        url_uploader: snapshot_person_href(snapshot),
+      },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[
+          [bbox[0],bbox[1]],
+          [bbox[0],bbox[3]],
+          [bbox[2],bbox[3]],
+          [bbox[2],bbox[1]],
+          [bbox[0],bbox[1]]
+        ]]
+      }
+    })
+  end
 end

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -227,6 +227,7 @@ class Snapshot < ActiveRecord::Base
       if atlas_slug && page_number
         begin
           updates[:page] = Atlas.unscoped.friendly.find(atlas_slug).pages.find_by_page_number(page_number)
+          updates[:atlas_id] = updates[:page].atlas_id
         rescue ActiveRecord::RecordNotFound
         end
       end

--- a/app/views/snapshots/new.html.erb
+++ b/app/views/snapshots/new.html.erb
@@ -12,7 +12,6 @@
       callback_url: snapshots_url,
       callback_param: "snapshot[s3_scene_url]",
       expiration: 24.hours.from_now.utc.iso8601,
-      acl: "private",
       class: "upload-form",
       max_file_size: 25.megabytes do %>
       <%= file_field_tag :file, multiple: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require 'api_constraints'
+
 Rails.application.routes.draw do
   devise_for :users
 
@@ -39,4 +41,16 @@ Rails.application.routes.draw do
   resources :snapshots, :concerns => :pageable
 
   mount Rack::NotFound.new("public/404.html") => "activity.php"
+
+  # API routes: versioned, no HTML rendering
+  namespace :api, defaults: { format: 'json' } do
+    scope module: :v1, constraints: ApiConstraints.new(version: 1, default: true) do
+      resources :atlases, except: [:new, :edit]
+      get '/atlases/:id/page/:page_number' => 'atlases#page'
+      get '/atlases/:id/status'            => 'atlases#status'
+      resources :snapshots, except: [:new, :edit]
+      get '/snapshots/:id/status'          => 'snapshots#status'
+      get '/s3_upload/:filename'           => 's3_upload#show'
+    end
+  end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,8 +18,8 @@ development:
   secret_key_base: 43a5df1c68d5c8ff9763cf434fc4ae8e3328918fc6d7081940d8cc268fbea7b48c070a3595b5310cb01301687601c98c2a4df994f20b6034f9575926ed9d6915
   aws:
     <<: *aws_defaults
-    s3_bucket_name: "dev.files.fieldpapers.org"
-    s3_bucket_region: "us-east-1"
+    s3_bucket_name: <%= ENV["S3_BUCKET_NAME"] || "dev.files.fieldpapers.org" %>
+    s3_bucket_region: <%= ENV["AWS_REGION"] || "us-east-1" %>
 
 test:
   secret_key_base: 8250116f6fd746e5fc9258277e308b711c8e66e565cadb132a9911c7386e2253debd088c9c8d7b6c3455b205fad050e80cfb9a7c02c971bdf8439c654773fdcc

--- a/lib/api_constraints.rb
+++ b/lib/api_constraints.rb
@@ -1,0 +1,10 @@
+class ApiConstraints
+  def initialize(options)
+    @version = options[:version]
+    @default = options[:default]
+  end
+
+  def matches?(req)
+    @default || req.headers['Accept'].include?("application/vnd.example.v#{@version}")
+  end
+end

--- a/lib/api_constraints.rb
+++ b/lib/api_constraints.rb
@@ -5,6 +5,6 @@ class ApiConstraints
   end
 
   def matches?(req)
-    @default || req.headers['Accept'].include?("application/vnd.example.v#{@version}")
+    @default || req.headers['Accept'].include?("application/vnd.fieldpapers.v#{@version}")
   end
 end

--- a/test/controllers/api/v1/atlases_controller_test.rb
+++ b/test/controllers/api/v1/atlases_controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+require 'json'
+require 'fakeweb'
+
+module Api
+  module V1
+    class AtlasesControllerTest < ActionController::TestCase
+      test "should get atlas index" do
+        get :index, format: :json
+        assert_response :success
+      end
+
+      test "get single atlas" do
+        get :show, id: "1v00xegb", format: :json
+        assert_response :success
+        assert_match '"type":"FeatureCollection"', @response.body
+      end
+
+      # This isn't a very good test: since we don't have a task
+      # manager running, we don't actually render the atlas here.
+      test "create atlas" do
+        FakeWeb.register_uri(:any, %r|#{Regexp.quote(FieldPapers::TASK_BASE_URL)}/.*|, body: "OK")
+
+        data = { title: "", text: "",
+                 paper_size: "letter", orientation: "landscape",
+                 layout: "full-page", utm_grid: false, redcross_overlay: false,
+                 zoom: 15,
+                 provider: "http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png",
+                 west:  11.358833312988281, south: 47.222599386628744,
+                 east:  11.425437927246094, north: 47.25756309208489,
+                 rows: 1, cols: 1 }
+        post :create, atlas: data
+        assert_response :success
+      end
+
+      # test "should get update" do
+      #   get :update
+      #   assert_response :success
+      # end
+
+      test "delete atlas" do
+        delete :destroy, id: "3lwnzva3", format: :json
+        assert_response :success
+        get :show, id: "3lwnzva3", format: :json
+        assert_response :not_found
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/s3_upload_controller_test.rb
+++ b/test/controllers/api/v1/s3_upload_controller_test.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class S3UploadControllerTest < ActionController::TestCase
+      test "new snapshot upload info" do
+        get :show, filename: 'snap-1.png', format: :json
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/snapshots_controller_test.rb
+++ b/test/controllers/api/v1/snapshots_controller_test.rb
@@ -5,6 +5,13 @@ require 'fakeweb'
 module Api
   module V1
     class SnapshotsControllerTest < ActionController::TestCase
+      def s3_url(path)
+        bucket = Rails.application.secrets.aws["s3_bucket_name"]
+        region = Rails.application.secrets.aws["s3_region_name"] || 'us-east-1'
+        s3 = region == 'us-east-1' ? 's3' : 's3-' + region
+        "https://#{bucket}.#{s3}.amazonaws.com#{path}"
+      end
+
       test "should get snapshot index" do
         get :index, format: :json
         assert_response :success
@@ -21,8 +28,7 @@ module Api
         FakeWeb.register_uri(:any, %r|#{Regexp.quote(FieldPapers::TASK_BASE_URL)}/.*|, body: "OK")
         FakeWeb.register_uri(:any, %r|https://#{bucket}\.s3.*\.amazonaws\.com/uploads/.*|, body: "OK")
 
-        scene_url = 'https://fieldpapers-dev.s3-us-west-2.amazonaws.com/' +
-                    'uploads/L_D1_XpVixCgHixHVP4RYg/snap-1.png'
+        scene_url = s3_url("/uploads/L_D1_XpVixCgHixHVP4RYg/snap-1.png")
         post :create, s3_scene_url: scene_url
         assert_response :success
       end

--- a/test/controllers/api/v1/snapshots_controller_test.rb
+++ b/test/controllers/api/v1/snapshots_controller_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+require 'json'
+require 'fakeweb'
+
+module Api
+  module V1
+    class SnapshotsControllerTest < ActionController::TestCase
+      test "should get snapshot index" do
+        get :index, format: :json
+        assert_response :success
+      end
+
+      test "get single snapshot" do
+        get :show, id: "77btuvr8", format: :json
+        assert_response :success
+        assert_match '"type":"FeatureCollection"', @response.body
+      end
+
+      test "create snapshot" do
+        bucket = Regexp.quote(Rails.application.secrets.aws["s3_bucket_name"])
+        FakeWeb.register_uri(:any, %r|#{Regexp.quote(FieldPapers::TASK_BASE_URL)}/.*|, body: "OK")
+        FakeWeb.register_uri(:any, %r|https://#{bucket}\.s3.*\.amazonaws\.com/uploads/.*|, body: "OK")
+
+        scene_url = 'https://fieldpapers-dev.s3-us-west-2.amazonaws.com/' +
+                    'uploads/L_D1_XpVixCgHixHVP4RYg/snap-1.png'
+        post :create, s3_scene_url: scene_url
+        assert_response :success
+      end
+
+      test "delete snapshot" do
+        delete :destroy, id: "5nuv8bki", format: :json
+        assert_response :success
+        get :show, id: "5nuv8bki", format: :json
+        assert_response :not_found
+      end
+    end
+  end
+end

--- a/test/controllers/atlases_controller_test.rb
+++ b/test/controllers/atlases_controller_test.rb
@@ -1,7 +1,4 @@
 require 'test_helper'
 
 class AtlasesControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
 end

--- a/test/fixtures/atlases.yml
+++ b/test/fixtures/atlases.yml
@@ -37,3 +37,73 @@
 #  failed_at      :datetime
 #  workflow_state :string(255)
 #
+
+tstatl1:
+  id:             4
+  user_id:        NULL
+  slug:           "1v00xegb"
+  title:          ""
+  text:           ""
+  west:           11.338233947753904
+  south:          47.21350504374459
+  east:           11.471443176269531
+  north:          47.24847474828181
+  zoom:           14
+  rows:           1
+  cols:           2
+  provider:       "http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png"
+  paper_size:     "letter"
+  orientation:    "landscape"
+  layout:         "full-page"
+  pdf_url:        "https://fieldpapers-dev.s3.amazonaws.com/atlases/1v00xegb/atlas-1v00xegb.pdf"
+  preview_url:    NULL
+  country_name:   NULL
+  country_woeid:  NULL
+  region_name:    NULL
+  region_woeid:   NULL
+  place_name:     NULL
+  place_woeid:    NULL
+  progress:       1
+  private:        0
+  cloned_from:    NULL
+  refreshed_from: NULL
+  created_at:     "2015-11-04 21:23:38"
+  updated_at:     "2015-11-04 21:24:25"
+  composed_at:    "2015-11-04 21:24:25"
+  failed_at:      NULL
+  workflow_state: "complete"
+
+tstatl2:
+  id:             5
+  user_id:        NULL
+  slug:           "3lwnzva3"
+  title:          ""
+  text:           ""
+  west:           2.2745132446289062
+  south:          48.840090929598006
+  east:           2.3411521911621014
+  north:          48.87397380289261
+  zoom:           15
+  rows:           1
+  cols:           1
+  provider:       "http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png"
+  paper_size:     "letter"
+  orientation:    "landscape"
+  layout:         "full-page"
+  pdf_url:        "https://fieldpapers-dev.s3.amazonaws.com/atlases/3lwnzva3/atlas-3lwnzva3.pdf"
+  preview_url:    NULL
+  country_name:   NULL
+  country_woeid:  NULL
+  region_name:    NULL
+  region_woeid:   NULL
+  place_name:     NULL
+  place_woeid:    NULL
+  progress:       1
+  private:        0
+  cloned_from:    NULL
+  refreshed_from: NULL
+  created_at:     "2015-11-04 21:31:02"
+  updated_at:     "2015-11-04 21:31:21"
+  composed_at:    "2015-11-04 21:31:21"
+  failed_at:      NULL
+  workflow_state: "complete"

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -23,3 +23,87 @@
 #  composed_at   :datetime
 #  pdf_url       :string(255)
 #
+
+tstpage1:
+  id:            7
+  atlas_id:      4
+  page_number:   "i"
+  west:          11.324913024902342
+  south:         47.192523221022256
+  east:          11.484764099121094
+  north:         47.26945657100414
+  zoom:          14
+  provider:      "http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png"
+  preview_url:   NULL
+  country_name:  NULL
+  country_woeid: NULL
+  region_name:   NULL
+  place_name:    NULL
+  place_woeid:   NULL
+  created_at:    "2015-11-04 21:23:38"
+  updated_at:    "2015-11-04 21:24:17"
+  composed_at:   "2015-11-04 21:24:17"
+  pdf_url:       "https://fieldpapers-dev.s3.amazonaws.com/atlases/1v00xegb/atlas-1v00xegb.pdf"
+
+tstpage2:
+  id:            8
+  atlas_id:      4
+  page_number:   "A1"
+  west:          11.338233947753904
+  south:         47.21350504374459
+  east:          11.404838562011719
+  north:         47.24847474828181
+  zoom:          15
+  provider:      "http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png"
+  preview_url:   NULL
+  country_name:  NULL
+  country_woeid: NULL
+  region_name:   NULL
+  place_name:    NULL
+  place_woeid:   NULL
+  created_at:    "2015-11-04 21:23:38"
+  updated_at:    "2015-11-04 21:24:06"
+  composed_at:   "2015-11-04 21:24:06"
+  pdf_url:       "https://fieldpapers-dev.s3.amazonaws.com/atlases/1v00xegb/1v00xegb-A1.pdf"
+
+tstpage3:
+  id:            9
+  atlas_id:      4
+  page_number:   "A2"
+  west:          11.404838562011719
+  south:         47.21350504374459
+  east:          11.471443176269531
+  north:         47.24847474828181
+  zoom:          15
+  provider:      "http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png"
+  preview_url:   NULL
+  country_name:  NULL
+  country_woeid: NULL
+  region_name:   NULL
+  place_name:    NULL
+  place_woeid:   NULL
+  created_at:    "2015-11-04 21:23:38"
+  updated_at:    "2015-11-04 21:24:14"
+  composed_at:   "2015-11-04 21:24:14"
+  pdf_url:       "https://fieldpapers-dev.s3.amazonaws.com/atlases/1v00xegb/1v00xegb-A2.pdf"
+
+tstpage4:
+  id:            10
+  atlas_id:      5
+  page_number:   "A1"
+  west:          2.2745132446289062
+  south:         48.840090929598006
+  east:          2.3411521911621014
+  north:         48.87397380289261
+  zoom:          15
+  provider:      "http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png"
+  preview_url:   NULL
+  country_name:  NULL
+  country_woeid: NULL
+  region_name:   NULL
+  place_name:    NULL
+  place_woeid:   NULL
+  created_at:    "2015-11-04 21:31:02"
+  updated_at:    "2015-11-04 21:31:15"
+  composed_at:   "2015-11-04 21:31:15"
+  pdf_url:       "https://fieldpapers-dev.s3.amazonaws.com/atlases/3lwnzva3/3lwnzva3-A1.pdf"

--- a/test/fixtures/snapshots.yml
+++ b/test/fixtures/snapshots.yml
@@ -43,3 +43,89 @@
 #  geotiff_url        :string(255)
 #  failed_at          :datetime
 #
+
+tstsnap1:
+  id:                 7
+  slug:               "77btuvr8"
+  user_id:            NULL
+  page_id:            8
+  page_url:           "http://0.0.0.0:3000/atlases/1v00xegb/A1"
+  min_row:            NULL
+  max_row:            NULL
+  min_column:         NULL
+  max_column:         NULL
+  min_zoom:           NULL
+  max_zoom:           NULL
+  description:        NULL
+  private:            0
+  has_geotiff:        "no"
+  has_geojpeg:        "no"
+  base_url:           NULL
+  uploaded_file:      NULL
+  country_name:       NULL
+  country_woeid:      NULL
+  region_name:        NULL
+  region_woeid:       NULL
+  place_name:         NULL
+  place_woeid:        NULL
+  progress:           1
+  created_at:         "2015-11-04 21:27:49"
+  updated_at:         "2015-11-04 21:28:46"
+  decoded_at:         "2015-11-04 21:28:45"
+  scene_file_name:    "/dev.files.fieldpapers.org/uploads%2F1446672452510-ion40pa393rz4cxr-61da9bf9ae9f72fb17622701a581386d%2Fsnap-1.png"
+  scene_content_type: "image/png"
+  scene_file_size:    7753210
+  scene_updated_at:   NULL
+  s3_scene_url:       "https://s3.amazonaws.com/dev.files.fieldpapers.org/uploads/1446672452510-ion40pa393rz4cxr-61da9bf9ae9f72fb17622701a581386d/snap-1.png"
+  atlas_id:           4
+  west:               11.3382
+  south:              47.2135
+  east:               11.4048
+  north:              47.2485
+  zoom:               15
+  geotiff_url:        "https://fieldpapers-dev.s3.amazonaws.com/snapshots/77btuvr8/field-paper-77btuvr8.tiff"
+  failed_at:          NULL
+  workflow_state:     "complete"
+
+tstsnap2:
+  id:                 8
+  slug:               "5nuv8bki"
+  user_id:            NULL
+  page_id:            9
+  page_url:           "http://0.0.0.0:3000/atlases/1v00xegb/A2"
+  min_row:            NULL
+  max_row:            NULL
+  min_column:         NULL
+  max_column:         NULL
+  min_zoom:           NULL
+  max_zoom:           NULL
+  description:        NULL
+  private:            0
+  has_geotiff:        "no"
+  has_geojpeg:        "no"
+  base_url:           NULL
+  uploaded_file:      NULL
+  country_name:       NULL
+  country_woeid:      NULL
+  region_name:        NULL
+  region_woeid:       NULL
+  place_name:         NULL
+  place_woeid:        NULL
+  progress:           1
+  created_at:         "2015-11-04 21:29:16"
+  updated_at:         "2015-11-04 21:30:09"
+  decoded_at:         "2015-11-04 21:30:09"
+  scene_file_name:    "/dev.files.fieldpapers.org/uploads%2F1446672540731-m5ccyza814d0lik9-8e148f85e49909d6601bb4352d5c3130%2Fsnap-2.png"
+  scene_content_type: "image/png"
+  scene_file_size:    7852703
+  scene_updated_at:   NULL
+  s3_scene_url:       "https://s3.amazonaws.com/dev.files.fieldpapers.org/uploads/1446672540731-m5ccyza814d0lik9-8e148f85e49909d6601bb4352d5c3130/snap-2.png"
+  atlas_id:           4
+  west:               11.4048
+  south:              47.2135
+  east:               11.4714
+  north:              47.2485
+  zoom:               15
+  geotiff_url:        "https://fieldpapers-dev.s3.amazonaws.com/snapshots/5nuv8bki/field-paper-5nuv8bki.tiff"
+  failed_at:          NULL
+  workflow_state:     "complete"


### PR DESCRIPTION
(Re-issuing #14 now that the AWS quickstart has been merged.)

This is a first pass at a fully populated RESTful(ish) API for Field Papers:

 * the API endpoints are all in a separate `/api` namespace;
 * the API is versioned (using the `Accept: application/vnd....` approach);
 * there are endpoints for most manipulations of atlases and snapshots.

There's enough functionality in the API to create an atlas, download pages, upload snapshot images, create snapshots from the images and download the resulting GeoTIFFs.  (Snapshot image upload to S3 is done using pre-signed URLs instead of the browser-based approach used in the main part of `fp-web`, just because this is a simpler method for API-using clients.)

There are definitely gaps in this, and there are definitely things that are done wrong, but I think it's not a bad start.  This PR follows right on from the `aws-quick-start` one I did a little while ago, mostly to be able to use the "non-default region" stuff for S3.

/cc @ian-ross