### PR TITLE
Support relocating Field Papers to a subdir url

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ they are available to the environment in which Rails is running.
 * `MAIL_ORIGIN` - From address to use for automated system emails.
 * `MAIL_SOURCE_ARN` - AWS SES mail source identity. (Associated credentials must
   be granted access to send from this)
-* `BASE_URL` - Site base URL.
+* `BASE_URL` - Site base URL (Network-accessible, i.e. from a Docker container).
 * `S3_BUCKET_NAME` - S3 bucket for file storage. Defaults to
   `dev.files.fieldpapers.org` (development), `test.files.fieldpapers.org`
   (test), and `files.fieldpapers.org` (production).
@@ -228,8 +228,6 @@ they are available to the environment in which Rails is running.
   bucket(s).
 * `AWS_SECRET_ACCESS_KEY` - Corresponding secret.
 * `AWS_REGION` - AWS region to use for services.
-* `API_BASE_URL` - Network-accessible (i.e. from a Docker container) base URL
-  rendered into PDFs.
 * `BASE_URL` - Base URL, e.g. `http://fieldpapers.org`.
 * `TASK_BASE_URL` - Base URL for the task server (probably an instance of
   [fp-tasks](https://github.com/fieldpapers/fp-tasks)).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -22,7 +22,7 @@ etc.) are present, the `boot2docker` VM may not be running.
 
 First, check to see that the IP/hostname present in the PDF corresponds to your
 development instance (i.e. isn't `fieldpapers.org`; this can be configured by
-setting `API_BASE_URL`). Second, ensure that your docker containers can access
+setting `BASE_URL`). Second, ensure that your docker containers can access
 it using that name. Using `<hostname>.local` is a convenient way to do so and
 to survive DHCP renewals.
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,7 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-run Rails.application
+
+map ENV['RAILS_RELATIVE_URL_ROOT'] || "/" do
+  run Rails.application
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ web:
     - RAILS_ENV=development
     - DATABASE_URL=mysql2://fieldpapers:fieldpapers@db/fieldpapers_development
     - TEST_DATABASE_URL=mysql2://fieldpapers:fieldpapers@db/fieldpapers_test
-    - API_BASE_URL=http://fieldpapers.local:3000/
     - BASE_URL=http://fieldpapers.local:3000
     - TILE_BASE_URL=http://fieldpapers.local:8080
     - TASK_BASE_URL=http://localhost:8080

--- a/sample-production.env
+++ b/sample-production.env
@@ -1,4 +1,3 @@
-API_BASE_URL=http://fieldpapers.org/
 AWS_ACCESS_KEY_ID=<redacted>
 AWS_REGION=us-east-1
 AWS_SECRET_ACCESS_KEY=<redacted>


### PR DESCRIPTION
Use `RAILS_RELATIVE_URL_ROOT` environment to relocate path to Field Papers.