### PR TITLE
Accept and store snapshot uploads locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ vendor/bundle
 venv
 .tx/fieldpapers.www/
 public/assets/
+public/snapshots/

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ they are available to the environment in which Rails is running.
   Defaults to `:rails_root/public` (to match the `STATIC_URI_PREFIX` default).
 * `STATIC_URI_PREFIX` - Prefix to apply to static paths (e.g.
   http://example.org/path) to allow them to resolve. Defaults to `BASE_URL`.
+* `PERSIST` - File persistence. Can be `local` or `s3`. Defaults to `s3`.
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ they are available to the environment in which Rails is running.
 * `SENTRY_DSN` - Sentry DSN for exception logging. Optional.
 * `MAPZEN_SEARCH_KEY` - A Mapzen Search API key, obtained from
   [mapzen.com/developers](https://mapzen.com/developers).
+* `STATIC_PATH` - Path to write static files to. Must be HTTP-accessible.
+  Defaults to `:rails_root/public` (to match the `STATIC_URI_PREFIX` default).
+* `STATIC_URI_PREFIX` - Prefix to apply to static paths (e.g.
+  http://example.org/path) to allow them to resolve. Defaults to `BASE_URL`.
 
 ### Running Tests
 

--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -72,9 +72,19 @@ class SnapshotsController < ApplicationController
   private
 
   def snapshot_upload_params
-    params.require(:snapshot)
-      .permit(:scene)
-      .merge(uploader: current_user)
+    case FieldPapers::PERSIST
+    when "local"
+      params.require(:snapshot)
+        .permit(:scene)
+        .merge(uploader: current_user)
+    when "s3"
+      params.require(:snapshot)
+        .permit(:s3_scene_url)
+        .merge(scene_file_name: params.permit(:filepath)[:filepath],
+               scene_content_type: params.permit(:filetype)[:filetype],
+               scene_file_size: params.permit(:filesize)[:filesize])
+        .merge(uploader: current_user)
+    end
   end
 
   def snapshot_update_params

--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -9,11 +9,17 @@ class SnapshotsController < ApplicationController
   # allow API usage
   skip_before_filter :verify_authenticity_token, only: :update
 
+  def new
+    @snapshot = Snapshot.new
+  end
+
   # @http_method XHR POST
   # @url /snapshots
   def create
     @snapshot = Snapshot.create!(snapshot_upload_params)
     @snapshot.process!
+
+    redirect_to snapshot_url(@snapshot) unless request.xhr?
   end
 
   def index
@@ -67,10 +73,7 @@ class SnapshotsController < ApplicationController
 
   def snapshot_upload_params
     params.require(:snapshot)
-      .permit(:s3_scene_url)
-      .merge(scene_file_name: params.permit(:filepath)[:filepath],
-             scene_content_type: params.permit(:filetype)[:filetype],
-             scene_file_size: params.permit(:filesize)[:filesize])
+      .permit(:scene)
       .merge(uploader: current_user)
   end
 

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -60,17 +60,34 @@ class Snapshot < ActiveRecord::Base
 
   # paperclip (attachment) configuration
 
-  has_attached_file :scene, {
-    hash_secret: "whatever",
-    url: "/snapshots/:hash.:extension",
-  }
+  # TODO stick this in a Module and include/extend it accordingly
+  case FieldPapers::PERSIST
+  when "local"
+    has_attached_file :scene, {
+      hash_secret: "whatever",
+      url: "/snapshots/:hash.:extension",
+    }
+
+    validates_attachment_content_type :scene, content_type: /\Aimage\/.*\Z/
+  when "s3"
+    def self.s3_url(bucket, region)
+      region = region || 'us-east-1'
+      s3 = region == 'us-east-1' ? 's3' : 's3-' + region
+      %r{\Ahttps?:\/\/#{s3}\.amazonaws\.com\/#{bucket}\/(?<path>uploads\/.+\/(?<filename>.+))\z}.freeze
+    end
+
+    # Environment-specific direct upload url verifier screens for malicious posted upload locations.
+    S3_UPLOAD_URL_FORMAT = s3_url(Rails.application.secrets.aws["s3_bucket_name"],
+                                  Rails.application.secrets.aws["s3_bucket_region"])
+
+    has_attached_file :scene
+
+    validates :s3_scene_url, presence: true, format: { with: S3_UPLOAD_URL_FORMAT }
+    validates_attachment_content_type :scene, :content_type => /\Aimage\/.*\Z/
+  end
 
   # callbacks
   after_initialize :apply_defaults
-
-  # validations
-
-  validates_attachment_content_type :scene, content_type: /\Aimage\/.*\Z/
 
   # relations
 
@@ -131,10 +148,6 @@ class Snapshot < ActiveRecord::Base
     -> user {
       where(user_id: user)
     }
-
-  # validations
-
-  validates_attachment_content_type :scene, :content_type => /\Aimage/
 
   # workflow states
 
@@ -273,7 +286,7 @@ class Snapshot < ActiveRecord::Base
   end
 
   def image_url
-    FieldPapers::STATIC_URI_PREFIX + scene.url
+    s3_scene_url || FieldPapers::STATIC_URI_PREFIX + scene.url
   end
 
   def latitude

--- a/app/views/snapshots/new.html.erb
+++ b/app/views/snapshots/new.html.erb
@@ -10,10 +10,29 @@
   <div class="twelve columns">
     <p class="status-text error msg"><%= _("Something went wrong! Please review the <strong>rules</strong> below and try again.") %></p>
 
+  <% case FieldPapers::PERSIST %>
+  <% when "local" %>
     <%= form_for @snapshot, url: snapshots_path, html: { multipart: true } do |f| %>
       <%= f.file_field :scene %><br>
       <%= f.submit "Upload" %>
+  <% end %>
+  <% when "s3" %>
+    <%= s3_uploader_form id: "s3_uploader",
+      callback_url: snapshots_url,
+      callback_param: "snapshot[s3_scene_url]",
+      expiration: 24.hours.from_now.utc.iso8601,
+      acl: "private",
+      class: "upload-form",
+      max_file_size: 25.megabytes do %>
+      <%= file_field_tag :file, multiple: true %>
     <% end %>
+
+    <div class="upload js-progress-bars">
+      <div class="progress progress-striped active">
+        <div class="bar" style="width: 0%"></div>
+      </div>
+    </div>
+  <% end %>
   </div>
 </div>
 
@@ -27,3 +46,36 @@
     </ul>
   </div>
 </div>
+
+<% if FieldPapers::PERSIST == "s3" %>
+<% content_for :foot do %>
+  <script>
+    $(function() {
+      $("#s3_uploader").S3Uploader(
+        {
+          remove_completed_progress_bar: false,
+          allow_multiple_files: false,
+          progress_bar_target: $('.js-progress-bars')
+        }
+      );
+
+      $("#s3_uploader").bind("s3_upload_complete", function(e, content) {
+        console.log('Upload complete');
+        console.log(e, content);
+      });
+
+      $("#s3_uploader").bind("s3_upload_failed", function(e, content) {
+        console.log('Upload error');
+        console.error(e, content);
+        $('body').addClass('error').removeClass('uploading');
+      });
+
+      $("#s3_uploader").bind("s3_uploads_start", function(e, content) {
+        $('body').addClass('uploading').removeClass('error');
+      });
+
+    });
+
+  </script>
+<% end %>
+<% end %>

--- a/app/views/snapshots/new.html.erb
+++ b/app/views/snapshots/new.html.erb
@@ -8,24 +8,12 @@
     <p class=""><%= _("Choose an atlas page to upload. We'll work out where it goes (using the QR code).") %></p>
   </div>
   <div class="twelve columns">
-    <%= s3_uploader_form id: "s3_uploader",
-      callback_url: snapshots_url,
-      callback_param: "snapshot[s3_scene_url]",
-      expiration: 24.hours.from_now.utc.iso8601,
-      acl: "private",
-      class: "upload-form",
-      max_file_size: 25.megabytes do %>
-      <%= file_field_tag :file, multiple: true %>
-    <% end %>
-
-    <div class="upload js-progress-bars">
-      <div class="progress progress-striped active">
-        <div class="bar" style="width: 0%"></div>
-      </div>
-    </div>
-
     <p class="status-text error msg"><%= _("Something went wrong! Please review the <strong>rules</strong> below and try again.") %></p>
 
+    <%= form_for @snapshot, url: snapshots_path, html: { multipart: true } do |f| %>
+      <%= f.file_field :scene %><br>
+      <%= f.submit "Upload" %>
+    <% end %>
   </div>
 </div>
 
@@ -39,34 +27,3 @@
     </ul>
   </div>
 </div>
-
-<% content_for :foot do %>
-  <script>
-    $(function() {
-      $("#s3_uploader").S3Uploader(
-        {
-          remove_completed_progress_bar: false,
-          allow_multiple_files: false,
-          progress_bar_target: $('.js-progress-bars')
-        }
-      );
-
-      $("#s3_uploader").bind("s3_upload_complete", function(e, content) {
-        console.log('Upload complete');
-        console.log(e, content);
-      });
-
-      $("#s3_uploader").bind("s3_upload_failed", function(e, content) {
-        console.log('Upload error');
-        console.error(e, content);
-        $('body').addClass('error').removeClass('uploading');
-      });
-
-      $("#s3_uploader").bind("s3_uploads_start", function(e, content) {
-        $('body').addClass('uploading').removeClass('error');
-      });
-
-    });
-
-  </script>
-<% end %>

--- a/config/initializers/fieldpapers.rb
+++ b/config/initializers/fieldpapers.rb
@@ -6,4 +6,5 @@ module FieldPapers
   STATIC_PATH = ENV["STATIC_PATH"] || ":rails_root/public"
   TASK_BASE_URL = ENV["TASK_BASE_URL"] || "http://tasks.fieldpapers.org"
   TILE_BASE_URL = ENV["TILE_BASE_URL"] || "http://tiles.fieldpapers.org"
+  PERSIST = ENV["PERSIST"] || "s3"
 end

--- a/config/initializers/fieldpapers.rb
+++ b/config/initializers/fieldpapers.rb
@@ -2,6 +2,8 @@ require 'socket'
 
 module FieldPapers
   BASE_URL = ENV["BASE_URL"] || "http://fieldpapers.org"
+  STATIC_URI_PREFIX = ENV["STATIC_URI_PREFIX"] || BASE_URL
+  STATIC_PATH = ENV["STATIC_PATH"] || ":rails_root/public"
   TASK_BASE_URL = ENV["TASK_BASE_URL"] || "http://tasks.fieldpapers.org"
   TILE_BASE_URL = ENV["TILE_BASE_URL"] || "http://tiles.fieldpapers.org"
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,4 +1,38 @@
-Paperclip::Attachment.default_options.merge!(
-  storage: :filesystem,
-  path: "#{FieldPapers::STATIC_PATH}:url",
-)
+case FieldPapers::PERSIST
+when "local"
+  Paperclip::Attachment.default_options.merge!(
+    storage: :filesystem,
+    path: "#{FieldPapers::STATIC_PATH}:url",
+  )
+when "s3"
+  if Rails.application.secrets.aws["access_key_id"] && Rails.application.secrets.aws["secret_access_key"]
+    Paperclip::Attachment.default_options.merge!(
+      storage:              :s3,
+      s3_credentials: {
+        access_key_id:      Rails.application.secrets.aws["access_key_id"],
+        secret_access_key:  Rails.application.secrets.aws["secret_access_key"],
+        bucket:             Rails.application.secrets.aws["s3_bucket_name"]
+      },
+      s3_permissions:       :private,
+      s3_protocol:          'https'
+    )
+  else
+    Paperclip::Attachment.default_options.merge!(
+      storage:              :s3,
+
+      # If no AWS credentials were provided, assume we're running on EC2 with an
+      # IAM role.
+      s3_credentials: lambda { |a|
+        prov = AWS::Core::CredentialProviders::EC2Provider.new
+
+        return {
+          bucket: Rails.application.secrets.aws["s3_bucket_name"],
+          access_key_id: prov.credentials[:access_key_id],
+          secret_access_key: prov.credentials[:secret_access_key]
+        }
+      },
+      s3_permissions:       :private,
+      s3_protocol:          'https'
+    )
+  end
+end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,32 +1,4 @@
-if Rails.application.secrets.aws["access_key_id"] && Rails.application.secrets.aws["secret_access_key"]
-  Paperclip::Attachment.default_options.merge!(
-    # url:                  ':s3_domain_url',
-    # path:                 ':class/:attachment/:id/:style/:filename',
-    storage:              :s3,
-    s3_credentials: {
-      access_key_id:      Rails.application.secrets.aws["access_key_id"],
-      secret_access_key:  Rails.application.secrets.aws["secret_access_key"],
-      bucket:             Rails.application.secrets.aws["s3_bucket_name"]
-    },
-    s3_permissions:       :private,
-    s3_protocol:          'https'
-  )
-else
-  Paperclip::Attachment.default_options.merge!(
-    # url:                  ':s3_domain_url',
-    # path:                 ':class/:attachment/:id/:style/:filename',
-    storage:              :s3,
-    # Here, "production" is a custom deployment on Amazon Web
-    # Services, and we use temporary AWS credentials associated with
-    # the EC2 instance where we are running.  (See top-level README
-    # for more details.)
-    s3_credentials: lambda { |a|
-      prov = AWS::Core::CredentialProviders::EC2Provider.new
-      { bucket: Rails.application.secrets.aws["s3_bucket_name"],
-        access_key_id: prov.credentials[:access_key_id],
-        secret_access_key: prov.credentials[:secret_access_key] }
-    },
-    s3_permissions:       :private,
-    s3_protocol:          'https'
-  )
-end
+Paperclip::Attachment.default_options.merge!(
+  storage: :filesystem,
+  path: "#{FieldPapers::STATIC_PATH}:url",
+)


### PR DESCRIPTION
Removes `s3_direct_upload` and reconfigures paperclip to use local storage.

Matches environment variables in https://github.com/fieldpapers/fp-tasks/pull/3.

Still TODO: make S3 / local configurable (via `PERSIST` environment var?).

Refs fieldpapers/fieldpapers#207

/cc @jflemer-ndp 