### PR TITLE
View atlases and snapshots by current or any given user

### DIFF
--- a/app/assets/stylesheets/partials/common.scss
+++ b/app/assets/stylesheets/partials/common.scss
@@ -88,6 +88,13 @@ ul {
   font-weight: 800;
   font-size: 2rem;
   letter-spacing: 0.5px;
+
+  a.right {
+    display: inline-block;
+    position: absolute;
+    right: 0;
+    padding-right: 10px;
+  }
 }
 
 .inline-linkbar.bottom {

--- a/app/assets/stylesheets/partials/map-cards.scss
+++ b/app/assets/stylesheets/partials/map-cards.scss
@@ -16,7 +16,6 @@ $column-counts: 3;
   background-image: linear-gradient(45deg, #FFF, #F9F9F9);
   color: #666;
   vertical-align: top;
-  cursor: pointer;
 
   @media (#{$bp-larger-than-tablet}) {}
 }

--- a/app/controllers/atlases_controller.rb
+++ b/app/controllers/atlases_controller.rb
@@ -5,10 +5,11 @@ require "raven"
 class AtlasesController < ApplicationController
   # filters
 
-  has_scope :date,  only: :index
-  has_scope :month, only: :index
-  has_scope :place, only: :index
-  has_scope :user,  only: :index
+  has_scope :date,      only: :index
+  has_scope :month,     only: :index
+  has_scope :place,     only: :index
+  has_scope :user,      only: :index
+  has_scope :username,  only: :index
 
   # allow API usage
   skip_before_filter :verify_authenticity_token, only: :update

--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -5,6 +5,7 @@ class SnapshotsController < ApplicationController
   has_scope :month, only: :index
   has_scope :place, only: :index
   has_scope :user, only: :index
+  has_scope :username, only: :index
 
   # allow API usage
   skip_before_filter :verify_authenticity_token, only: :update

--- a/app/models/atlas.rb
+++ b/app/models/atlas.rb
@@ -133,13 +133,13 @@ class Atlas < ActiveRecord::Base
     includes(:creator)
       .where("#{self.table_name}.private = false")
       .where("#{self.table_name}.failed_at is null")
-      .order("created_at DESC")
+      .order("#{self.table_name}.created_at DESC")
   }
 
   scope :default, -> {
     includes(:creator)
       .where("#{self.table_name}.failed_at is null")
-      .order("created_at DESC")
+      .order("#{self.table_name}.created_at DESC")
   }
 
   scope :by_creator, -> (creator) {
@@ -168,6 +168,12 @@ class Atlas < ActiveRecord::Base
   scope :user,
     -> user {
       where(user_id: user)
+    }
+
+  scope :username,
+    -> username {
+      joins(:creator)
+      .where(users: {username: username})
     }
 
   # workflow states

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -149,6 +149,12 @@ class Snapshot < ActiveRecord::Base
       where(user_id: user)
     }
 
+  scope :username,
+    -> username {
+      joins(:uploader)
+      .where(users: {username: username})
+    }
+    
   # workflow states
 
   workflow do

--- a/app/views/atlases/_atlas.html.erb
+++ b/app/views/atlases/_atlas.html.erb
@@ -30,11 +30,11 @@
   <div class="no-wrap">
     <span class="atlas-status <% if atlas.failed? %>failed<% elsif atlas.incomplete? %>incomplete<% end %>"></span>
     <%= link_to atlas.title, atlas_path(atlas), {:class => "map-card-title embolden"} %><br>
-    <span class="map-card-creator small"><%= atlas.creator_name if atlas.creator %>&nbsp;</span><% if atlas.private? %><span class="private"><%= _("private") %></span><% end %>
+    <span class="map-card-creator small"><%= link_to(atlas.creator_name, atlases_path(username: atlas.creator.username)) if atlas.creator %>&nbsp;</span><% if atlas.private? %><span class="private"><%= _("private") %></span><% end %>
   </div>
 
   <div>
     <span class="map-card-pages small"><%= n_("%{count} page", "%{count} pages", atlas.atlas_pages) % {count: number_with_delimiter(atlas.atlas_pages)} %>,</span>
-    <span class="map-card-created small"><%= link_to _("%{time_period} ago") % { time_period: time_ago_in_words(atlas.created_at) }, atlases_path(month: atlas.created_at.strftime("%Y-%m")) %></span>
+    <span class="map-card-created small"><%= link_to _("%{time_period} ago") % { time_period: time_ago_in_words(atlas.created_at) }, atlases_path(params.slice(:date, :month, :place, :user, :username).merge(month: atlas.created_at.strftime("%Y-%m"))) %></span>
   </div>
 </li>

--- a/app/views/atlases/index.html.erb
+++ b/app/views/atlases/index.html.erb
@@ -3,7 +3,7 @@
 <div class="row">
   <div class="twelve columns map-container">
     <div id="map" class="map"></div>
-    <p class="inline-linkbar bottom"><%= n_("%{count} Atlas", "%{count} Atlases", @counts) % {count: number_with_delimiter(@counts) } %> | <%= link_to _("Snapshots"), snapshots_path %></p>
+    <p class="inline-linkbar bottom"><%= n_("%{count} Atlas", "%{count} Atlases", @counts) % {count: number_with_delimiter(@counts) } %> | <%= link_to _("Snapshots"), snapshots_path(username: current_user.try(:username)) %></p>
   </div>
 </div>
 

--- a/app/views/atlases/index.html.erb
+++ b/app/views/atlases/index.html.erb
@@ -9,7 +9,7 @@
         params[:username] ? _("All Atlases") : _("Your Atlases"),
         atlases_path(params[:username] ? nil : {username: current_user.try(:username)}),
         class: "right" 
-      ) if current_user.present? %>
+      ) if user_signed_in? %>
     </p>
   </div>
 </div>

--- a/app/views/atlases/index.html.erb
+++ b/app/views/atlases/index.html.erb
@@ -3,7 +3,14 @@
 <div class="row">
   <div class="twelve columns map-container">
     <div id="map" class="map"></div>
-    <p class="inline-linkbar bottom"><%= n_("%{count} Atlas", "%{count} Atlases", @counts) % {count: number_with_delimiter(@counts) } %> | <%= link_to _("Snapshots"), snapshots_path(username: current_user.try(:username)) %></p>
+    <p class="inline-linkbar bottom">
+      <%= n_("%{count} Atlas", "%{count} Atlases", @counts) % {count: number_with_delimiter(@counts) } %> | <%= link_to _("Snapshots"), snapshots_path(username: params[:username]) %>
+      <%= link_to(
+        params[:username] ? _("All Atlases") : _("Your Atlases"),
+        atlases_path(params[:username] ? nil : {username: current_user.try(:username)}),
+        class: "right" 
+      ) %>
+    </p>
   </div>
 </div>
 

--- a/app/views/atlases/index.html.erb
+++ b/app/views/atlases/index.html.erb
@@ -9,7 +9,7 @@
         params[:username] ? _("All Atlases") : _("Your Atlases"),
         atlases_path(params[:username] ? nil : {username: current_user.try(:username)}),
         class: "right" 
-      ) %>
+      ) if current_user.present? %>
     </p>
   </div>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -24,7 +24,7 @@
                     </a>
                 </li>
                 <li class="nav-item<%= " active" if ["watch"].include? current_nav_target %>">
-                    <a href="<%= atlases_path %>">
+                    <a href="<%= atlases_path(username: current_user.try(:username)) %>">
                         <div class="section"><%= _("WATCH") %></div>
                         <div class="desc"><%= _("recent activity") %></div>
                     </a>

--- a/app/views/snapshots/index.html.erb
+++ b/app/views/snapshots/index.html.erb
@@ -8,7 +8,7 @@
         params[:username] ? _("All Snapshots") : _("Your Snapshots"),
         snapshots_path(params[:username] ? nil : {username: current_user.try(:username)}),
         class: "right" 
-      ) %>
+      ) if current_user.present? %>
     </p>
   </div>
 </div>

--- a/app/views/snapshots/index.html.erb
+++ b/app/views/snapshots/index.html.erb
@@ -2,7 +2,14 @@
 
 <div class="row">
   <div class="twelve columns map-container">
-    <p class="inline-linkbar"><%= link_to _("Atlases"), atlases_path(username: current_user.try(:username)) %> | <%= n_("%{count} Snapshot", "%{count} Snapshots", @counts) % { count: number_with_delimiter(@counts) } %></p>
+    <p class="inline-linkbar">
+      <%= link_to _("Atlases"), atlases_path(username: params[:username]) %> | <%= n_("%{count} Snapshot", "%{count} Snapshots", @counts) % { count: number_with_delimiter(@counts) } %>
+      <%= link_to(
+        params[:username] ? _("All Snapshots") : _("Your Snapshots"),
+        snapshots_path(params[:username] ? nil : {username: current_user.try(:username)}),
+        class: "right" 
+      ) %>
+    </p>
   </div>
 </div>
 

--- a/app/views/snapshots/index.html.erb
+++ b/app/views/snapshots/index.html.erb
@@ -8,7 +8,7 @@
         params[:username] ? _("All Snapshots") : _("Your Snapshots"),
         snapshots_path(params[:username] ? nil : {username: current_user.try(:username)}),
         class: "right" 
-      ) if current_user.present? %>
+      ) if user_signed_in? %>
     </p>
   </div>
 </div>

--- a/app/views/snapshots/index.html.erb
+++ b/app/views/snapshots/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="twelve columns map-container">
-    <p class="inline-linkbar"><%= link_to _("Atlases"), atlases_path %> | <%= n_("%{count} Snapshot", "%{count} Snapshots", @counts) % { count: number_with_delimiter(@counts) } %></p>
+    <p class="inline-linkbar"><%= link_to _("Atlases"), atlases_path(username: current_user.try(:username)) %> | <%= n_("%{count} Snapshot", "%{count} Snapshots", @counts) % { count: number_with_delimiter(@counts) } %></p>
   </div>
 </div>
 


### PR DESCRIPTION
This PR adds the following functionality:

1. Add support for `username` scope.
2. Scope the "WATCH" link in the top nav to the signed-in user, if viewer is signed in. (By default, you'll see only your content.)
3. Add link to navbar in `/atlases` and `/snapshots` to toggle between your (signed-in user) content and all content.
4. Maintain the current `?username=` scope in the "Atlases" / "Snapshots" links.