### PR TITLE
Feature Flag that Disables Registration Confirmation Emails and Business Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,10 @@ they are available to the environment in which Rails is running.
 * `ATLAS_COMPLETE_WEBHOOKS` - A comma separated string of URLs. Optional. When an atlas
   moves to the state 'complete', fp-web will `POST` the JSON representation
   of the atlas to each URL.
+* `DISABLE_LOGIN_CONFIRMATIONS` - A value of `true` will not require
+  users to confirm their accounts after registration and will not send confirmation emails.
+  Optional. Defaults to `false` -- registration confirmations are required
+
 
 ### Running Tests
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,11 @@ class User < ActiveRecord::Base
     end
   end
 
+  # override Devise to not send confirmation
+  def confirmation_required?
+    false
+  end
+
   # instance methods
 
   def init

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,8 +24,11 @@ class User < ActiveRecord::Base
   attr_accessor :login
 
   # devise configuration (authentication)
-  devise :confirmable, :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  devise_mods = [:database_authenticatable, :registerable, :recoverable, :rememberable, :validatable]
+  if !Rails.application.config.disable_login_confirmations
+    devise_mods.push(:confirmable)
+  end
+  devise *devise_mods
 
   # generate a random id (since id is not currently auto-increment)
   after_initialize :init
@@ -58,11 +61,6 @@ class User < ActiveRecord::Base
     else
       where(conditions.to_h).first
     end
-  end
-
-  # override Devise to not send confirmation
-  def confirmation_required?
-    false
   end
 
   # instance methods

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,8 @@ module App
     config.after_initialize do
       Rails.application.routes.default_url_options[:host] = FieldPapers::BASE_URL
     end
+
+    # remove the Devise :confirmable module based on env variable
+    config.disable_login_confirmations = ENV['DISABLE_LOGIN_CONFIRMATIONS'] ? ENV['DISABLE_LOGIN_CONFIRMATIONS'] == 'true' : false
   end
 end


### PR DESCRIPTION
Keep the `confirmation` [schema around](https://github.com/fieldpapers/fp-web/blob/master/db/schema.rb#L167-L170) but disable confirmation business logic and emails by removing the `confirmable` module on startup. 

Note: creating new migrations from a site that has login confirmations disabled might remove these fields and that would be bad juju
