### PR TITLE
CSV grid of snapshot URLs for a given atlas

### DIFF
--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -26,6 +26,18 @@ class SnapshotsController < ApplicationController
   def index
     @snapshots = apply_scopes(Snapshot.unscoped).default.by_creator(current_user).page(params[:page])
     @counts = apply_scopes(Snapshot.unscoped).default.by_creator(current_user).count('id')
+
+    respond_to do |format|
+      format.html
+
+      # the grid CSV only makes sense if this is scoped beneath an atlas
+      if params[:atlas_id]
+        @atlas = Atlas.unscoped.friendly.find(params[:atlas_id])
+        format.csv do
+          headers["Content-Type"] ||= "text/csv"
+        end
+      end
+    end
   end
 
   def show

--- a/app/views/atlases/_atlas_activity.html.erb
+++ b/app/views/atlases/_atlas_activity.html.erb
@@ -23,6 +23,7 @@
     <ul>
       <li><a href="<%= atlas_path(format: :geojson) %>"><%= _("GeoJSON") %></a></li>
       <li><a href="<%= atlas_path(format: :csv) %>"><%= _("Plain Text (CSV)") %></a></li>
+      <li><a href="<%= atlas_snapshots_path(atlas, format: :csv) %>"><%= _("Snapshot URL Grid (CSV)") %></a></li>
     </ul>
 
     <h6 class="options-list-title"><%= _("Edit in...") %></h6>

--- a/app/views/snapshots/index.csv.erb
+++ b/app/views/snapshots/index.csv.erb
@@ -1,0 +1,27 @@
+<%
+row_names = [""] + ("A".."Z").to_a
+
+grid = ""
+
+(@atlas.cols + 1).times do |y|
+  (@atlas.rows + 1).times do |x|
+    grid << row_names[x] if y == 0
+    grid << y.to_s if x == 0 && y > 0
+
+    slugs = if y > 0 && x > 0
+      page_number = "#{row_names[x]}#{y}"
+      @atlas.pages.find_by_page_number(page_number).snapshots.pluck(:slug)
+    elsif y == 0 && x == 0
+      @atlas.pages.find_by_page_number("i").snapshots.pluck(:slug)
+    end
+
+    grid << "\"" + slugs.map { |slug| snapshot_url(slug) }.join(",") + "\"" if slugs
+
+    grid << "," unless x == @atlas.cols - 1
+  end
+
+  grid << "\n"
+end
+%>
+
+<%= grid.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   end
 
   resources :atlases, :concerns => :pageable do
+    resources :snapshots, only: [:index]
     member do
       get ':page_number' => 'pages#show',
         as: :atlas_page,


### PR DESCRIPTION
Sample output (for a 1x2 atlas):

```
"",A
1,"http://localhost:3000/snapshots/i5dv6fj0"
2,""
```

URLs are quoted and comma-delimited if more than one snapshot is present for a given page. Full URLs are included for ease of use w/ POSM, as the Field Papers JOSM plugin assumes `fieldpapers.org` if only a slug is provided.

URL pattern: `/atlas/:id/snapshots.csv`

Fixes fieldpapers/fieldpapers#217