### PR TITLE
valid tile template do not need jpg/png

### DIFF
--- a/app/assets/javascripts/fp/map/map-options.js
+++ b/app/assets/javascripts/fp/map/map-options.js
@@ -24,7 +24,7 @@
   // fits Leaflet's template requirements
   // http://leafletjs.com/reference.html#tilelayer
   utils.isTemplateString = function(str) {
-    var re = /^https?:\/\/(\{[s]\})?[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*\{[zxy]\}\/\{[zxy]\}\/\{[zxy]\}[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*(jpg|png)([\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*)?$/gi;
+    var re = /^https?:\/\/(\{[s]\})?[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*\{[zxy]\}\/\{[zxy]\}\/\{[zxy]\}[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*$/gi;
     return re.test(str);
   };
 

--- a/app/models/atlas.rb
+++ b/app/models/atlas.rb
@@ -104,7 +104,7 @@ class Atlas < ActiveRecord::Base
   # have multiple URL templates not including OVERLAYS
   def provider_valid
     p = get_provider_without_overlay
-    if /\Ahttps?:\/\/(\{[s]\})?[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*\{[zxy]\}\/\{[zxy]\}\/\{[zxy]\}[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*(jpg|png)([\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*)?\z/i !~ p
+    if /\Ahttps?:\/\/(\{[s]\})?[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*\{[zxy]\}\/\{[zxy]\}\/\{[zxy]\}[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*\z/i !~ p
       errors.add(:provider, "Invalid URL template")
     end
   end


### PR DESCRIPTION
mapbox tile endpoints do not have file suffixes, so adding mapbox tile source fails.  tile templates do not require the file suffix be specified.