### PR TITLE
disable custom layer validation

### DIFF
--- a/app/assets/javascripts/fp/map/map-options.js
+++ b/app/assets/javascripts/fp/map/map-options.js
@@ -24,8 +24,9 @@
   // fits Leaflet's template requirements
   // http://leafletjs.com/reference.html#tilelayer
   utils.isTemplateString = function(str) {
-    var re = /^https?:\/\/(\{[s]\})?[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*\{[zxy]\}\/\{[zxy]\}\/\{[zxy]\}[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*(jpg|png)([\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*)?$/gi;
-    return re.test(str);
+    return true;
+    // var re = /^https?:\/\/(\{[s]\})?[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*\{[zxy]\}\/\{[zxy]\}\/\{[zxy]\}[\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*(jpg|png)([\/\w\.\-\?\+\*_\|~:\[\]@#!\$'\(\),=&]*)?$/gi;
+    // return re.test(str);
   };
 
   utils.conformTemplate = function(template) {


### PR DESCRIPTION
Hi, I have been trying to create field papers with these layers:

```
googleSat = L.tileLayer('http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}',{
    maxZoom: 20,
    subdomains:['mt0','mt1','mt2','mt3']
});
```

```
    L.tileLayer(
        'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
        attribution: '&copy; '+mapLink+', '+wholink,
        maxZoom: 18,
        }).addTo(map);
```

Unfortunately neither of those urls are valid when passed in using ?provider due to the regex expecting a particular URL scheme. I propose disabling validation altogether so folks can pass in whatever they want