### PR TITLE
add more history and remove some references to info@stamen.com

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -20,7 +20,7 @@
 
         <h2>History</h2>
         <p>
-            The first version of Field Papers was <a href="http://content.stamen.com/announcing_field_papers">launched</a> in May 2012, in partnership with <a href="http://caerusassociates.com/ideas/maps-for-the-people-by-the-people/">Caerus Associates</a>. In June of 2013, we relaunched the site in collaboration with the <a href="http://www.usaid.gov/">U.S. Agency for International Development</a> (USAID) with major improvements to site performance, new metrics on atlas creation, as well as a general usability upgrade. 
+            The first version of Field Papers was <a href=https://stamen.com/announcing-field-papers-d861d59dd8be/">launched</a> in May 2012, in partnership with <a href="http://caerusassociates.com/ideas/maps-for-the-people-by-the-people/">Caerus Associates</a>. In June of 2013, <a href="https://stamen.com">Stamen</a> relaunched the site in collaboration with the <a href="http://www.usaid.gov/">U.S. Agency for International Development</a> (USAID) with major improvements to site performance, new metrics on atlas creation, as well as a general usability upgrade. In 2023, Field Papers <a href="https://stamen.com/a-new-home-for-field-papers/">became a project of OpenStreetMap US</a>.
         </p>
         
         <h2>Inspiration</h2>

--- a/app/views/home/advanced.fr.html.erb
+++ b/app/views/home/advanced.fr.html.erb
@@ -4,7 +4,7 @@
     <div class="twelve columns">
         <h2>Outils avancés</h2>
         <p>
-            Field Papers propose plusieurs outils d'automatisation et de personnalisation des cartes. Ces outils et processus sont mis à disposition pour des utilisateurs d'un bon niveau technique et aucun support (ou limité) n'est fourni. Si une fonctionnalité vous est importante, nous sommes disponibles pour définir une collaboration rémunérée. Décrivez votre proposition ou votre besoin à info@stamen.com (en anglais de préférence).
+            Field Papers propose plusieurs outils d'automatisation et de personnalisation des cartes. Ces outils et processus sont mis à disposition pour des utilisateurs d'un bon niveau technique et aucun support (ou limité) n'est fourni.
         </p>
         <ol>
             <li>

--- a/app/views/home/advanced.html.erb
+++ b/app/views/home/advanced.html.erb
@@ -4,7 +4,7 @@
     <div class="twelve columns">
         <h2>Advanced Tools</h2>
         <p>
-            Field Papers offers several automation and map customization tools. These tools and workflows are provided for technical users and limited to no support is provided. If a feature is important to you, we're available for hire. Send a request to info@stamen.com describing your proposal.
+            Field Papers offers several automation and map customization tools. These tools and workflows are provided for technical users and limited to no support is provided.
         </p>
         <ol>
             <li>


### PR DESCRIPTION
Just some small updates to the "History" on the about page, and the removal of two spots where we invite advanced users to email info@stamen.com to request features.